### PR TITLE
Delete depot code

### DIFF
--- a/project/src/edu/pace/GroupProject.java
+++ b/project/src/edu/pace/GroupProject.java
@@ -18,9 +18,41 @@ public class GroupProject {
      * @param args
      * @throws ClassNotFoundException
      * @throws SQLException
-     * @throws ClassNotFoundException
      */
-    public static void main(String args[]) throws SQLException, ClassNotFoundException {
+    public static void main(String args[]) throws ClassNotFoundException, SQLException {
 
+        Class.forName("com.mysql.cj.jdbc.Driver");
+        Connection conn = DriverManager.getConnection(
+                "jdbc:mysql://localhost:3306/test?useTimezone=true&serverTimezone=UTC",
+                System.getenv("DBUSER"),
+                System.getenv("DBPASSWORD")
+        );
+        // For atomicity
+        conn.setAutoCommit(false);
+
+        // For isolation
+        conn.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE);
+        Statement stmt = null;
+        try {
+            // create statement object
+            stmt = conn.createStatement();
+
+            // The depot d1 is deleted from Depot and Stock.
+            stmt.executeUpdate("DELETE FROM Stock WHERE dep_id='d1'");
+            stmt.executeUpdate("DELETE FROM depot WHERE dep_id='d1'");
+
+        } catch (SQLException e) {
+            System.out.println("A SQLException was thrown: " + e.getMessage());
+
+            // we only commit if all transactions were successful. atomicity
+            conn.rollback();
+            stmt.close();
+            conn.close();
+            return;
+        }
+
+        conn.commit();
+        stmt.close();
+        conn.close();
     }
 }


### PR DESCRIPTION
### Delete depot code

This is a first stab at the project delete depot code. I think it adheres to ACID because:

- *atomic* - the two delete statements get completed fully or not at all. Since autocommit is off, it only commits to the database if no exception was thrown.
- *consistency* - database foreign key constraints still hold. If we tried to delete just from Depot it would throw an exception because the foreign key dep_id would exist in Stock but the primary key would not exist in Depot.
- *isolation* - we ensure that transactions happen in isolation and concurrent ones can't happen simultaneously. We accomplish this through `conn.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE)`; this line specifies the following:
  - Statements cannot read data that has been modified but not yet committed by other transactions.
  - No other transactions can modify data that has been read by the current transaction until the current transaction completes.
  - Other transactions cannot insert new rows with key values that would fall in the range of keys read by any statements in the current transaction until the current transaction completes.




